### PR TITLE
New package: sngrep-1.8.2

### DIFF
--- a/srcpkgs/template
+++ b/srcpkgs/template
@@ -1,0 +1,26 @@
+# Template file for 'sngrep'
+pkgname=sngrep
+version=1.8.2
+revision=1
+build_style=gnu-configure
+configure_args="--with-openssl --with-pcap"
+hostmakedepends="automake libtool pkg-config"
+makedepends="
+	ncurses-devel
+	libpcap-devel
+	openssl-devel
+	gnutls-devel
+	libgcrypt-devel
+	pcre2-devel
+	zlib-devel
+"
+short_desc="Ncurses SIP message flow viewer"
+maintainer="Marco <startptm@pm.me>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/irontec/sngrep"
+distfiles="https://github.com/irontec/sngrep/releases/download/v${version}/sngrep-${version}.tar.gz"
+checksum="1cd05bddd531b353e3069c5243e7076b60a3ee907dbbc3c9c2834676ed8c4bac"
+pre_configure() {
+	   NOCONFIGURE=1 ./bootstrap.sh
+	   autoreconf -fi
+}


### PR DESCRIPTION
This adds sngrep 1.8.2 with dependencies for packet capture, TLS decryption, and ncurses UI.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
